### PR TITLE
Fix/correction sauvegarde bronze

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The Docker Compose file defines the `garage-meta` and `garage-data` volumes as *
 ```bash
 docker volume create garage-meta
 docker volume create garage-data
+docker compose build hn-producer
 docker-compose up -d
 ```
 

--- a/notebooks/01_kafka_to_bronze.ipynb
+++ b/notebooks/01_kafka_to_bronze.ipynb
@@ -162,63 +162,28 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Section 4 : Écriture vers Bronze (avec déduplication)"
-   ]
+   "source": "## Section 4 : Écriture vers Bronze (Append Only)"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from delta.tables import DeltaTable\n",
-    "\n",
-    "BRONZE_PATH = \"s3a://bronze/hackernews\"\n",
-    "CHECKPOINT_PATH = \"s3a://bronze/checkpoints\"\n",
-    "\n",
-    "def upsert_to_delta(batch_df, batch_id, table_path):\n",
-    "    \"\"\"Upsert (MERGE) vers Delta Lake - déduplique sur id\"\"\"\n",
-    "    if batch_df.isEmpty():\n",
-    "        return\n",
-    "    \n",
-    "    # Si la table existe, faire un MERGE\n",
-    "    if DeltaTable.isDeltaTable(sql_context.sparkSession, table_path):\n",
-    "        delta_table = DeltaTable.forPath(sql_context.sparkSession, table_path)\n",
-    "        delta_table.alias(\"target\").merge(\n",
-    "            batch_df.alias(\"source\"),\n",
-    "            \"target.id = source.id\"\n",
-    "        ).whenMatchedUpdateAll().whenNotMatchedInsertAll().execute()\n",
-    "    else:\n",
-    "        # Première écriture : créer la table\n",
-    "        batch_df.write.format(\"delta\").mode(\"overwrite\").save(table_path)"
-   ]
+   "source": "BRONZE_PATH = \"s3a://bronze/hackernews\"\nCHECKPOINT_PATH = \"s3a://bronze/checkpoints\"\n\ndef append_to_bronze(batch_df, batch_id, table_path):\n    \"\"\"Append vers Bronze - pas de déduplication, écriture rapide\"\"\"\n    if batch_df.isEmpty():\n        return\n    batch_df.write.format(\"delta\").mode(\"append\").save(table_path)"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Stream Stories → Bronze (avec MERGE)\n",
-    "stories_query = stories_parsed.writeStream \\\n",
-    "    .foreachBatch(lambda df, id: upsert_to_delta(df, id, f\"{BRONZE_PATH}/stories\")) \\\n",
-    "    .option(\"checkpointLocation\", f\"{CHECKPOINT_PATH}/stories\") \\\n",
-    "    .start()"
-   ]
+   "source": "# Stream Stories → Bronze (Append)\nstories_query = stories_parsed.writeStream \\\n    .foreachBatch(lambda df, id: append_to_bronze(df, id, f\"{BRONZE_PATH}/stories\")) \\\n    .option(\"checkpointLocation\", f\"{CHECKPOINT_PATH}/stories\") \\\n    .start()"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Stream Comments → Bronze (avec MERGE)\n",
-    "comments_query = comments_parsed.writeStream \\\n",
-    "    .foreachBatch(lambda df, id: upsert_to_delta(df, id, f\"{BRONZE_PATH}/comments\")) \\\n",
-    "    .option(\"checkpointLocation\", f\"{CHECKPOINT_PATH}/comments\") \\\n",
-    "    .start()"
-   ]
+   "source": "# Stream Comments → Bronze (Append)\ncomments_query = comments_parsed.writeStream \\\n    .foreachBatch(lambda df, id: append_to_bronze(df, id, f\"{BRONZE_PATH}/comments\")) \\\n    .option(\"checkpointLocation\", f\"{CHECKPOINT_PATH}/comments\") \\\n    .start()"
   },
   {
    "cell_type": "markdown",

--- a/utils/main.py
+++ b/utils/main.py
@@ -8,9 +8,10 @@ import requests
 from confluent_kafka import Producer
 
 KAFKA_SERVERS = os.getenv('KAFKA_BOOTSTRAP_SERVERS', 'kafka:9092')
-FETCH_INTERVAL = int(os.getenv('FETCH_INTERVAL', '120'))
+FETCH_INTERVAL = int(os.getenv('FETCH_INTERVAL', '90'))
 HN_API = 'https://hacker-news.firebaseio.com/v0'
-MAX_COMMENTS_PER_STORY = 20
+MAX_STORIES = 100
+MAX_COMMENTS_PER_STORY = 30
 
 seen_stories = set()
 seen_comments = set()
@@ -44,7 +45,7 @@ producer = Producer({
 
 while True:
     try:
-        story_ids = requests.get(f'{HN_API}/topstories.json', timeout=10).json()[:30]
+        story_ids = requests.get(f'{HN_API}/topstories.json', timeout=10).json()[:MAX_STORIES]
         for story_id in story_ids:
             if story_id in seen_stories:
                 continue

--- a/utils/main.py
+++ b/utils/main.py
@@ -11,6 +11,9 @@ KAFKA_SERVERS = os.getenv('KAFKA_BOOTSTRAP_SERVERS', 'kafka:9092')
 FETCH_INTERVAL = int(os.getenv('FETCH_INTERVAL', '60'))
 HN_API = 'https://hacker-news.firebaseio.com/v0'
 
+seen_stories = set()
+seen_comments = set()
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
@@ -42,28 +45,36 @@ while True:
     try:
         story_ids = requests.get(f'{HN_API}/topstories.json', timeout=10).json()[:30]
         for story_id in story_ids:
+            if story_id in seen_stories:
+                continue
+
             try:
                 story = requests.get(f'{HN_API}/item/{story_id}.json', timeout=10).json()
                 if not story or story.get('type') != 'story':
                     continue
-                
-                producer.produce('hn-stories', key=str(story_id).encode(), 
+
+                producer.produce('hn-stories', key=str(story_id).encode(),
                                 value=json.dumps(story).encode(), callback=delivery_callback)
+                seen_stories.add(story_id)
                 logger.info("Story produced: %s", story.get('title'))
-                
+
                 for comment_id in story.get('kids', [])[:50]:
+                    if comment_id in seen_comments:
+                        continue
+
                     try:
                         comment = requests.get(f'{HN_API}/item/{comment_id}.json', timeout=10).json()
                         if comment:
-                            producer.produce('hn-comments', key=str(comment_id).encode(), 
+                            producer.produce('hn-comments', key=str(comment_id).encode(),
                                             value=json.dumps(comment).encode(), callback=delivery_callback)
+                            seen_comments.add(comment_id)
                     except requests.RequestException as e:
                         logger.warning("Failed to fetch comment %s: %s", comment_id, e)
                         continue
             except requests.RequestException as e:
                 logger.warning("Failed to fetch story %s: %s", story_id, e)
                 continue
-        
+
         try:
             producer.flush()
         except Exception as e:

--- a/utils/main.py
+++ b/utils/main.py
@@ -8,8 +8,9 @@ import requests
 from confluent_kafka import Producer
 
 KAFKA_SERVERS = os.getenv('KAFKA_BOOTSTRAP_SERVERS', 'kafka:9092')
-FETCH_INTERVAL = int(os.getenv('FETCH_INTERVAL', '60'))
+FETCH_INTERVAL = int(os.getenv('FETCH_INTERVAL', '120'))
 HN_API = 'https://hacker-news.firebaseio.com/v0'
+MAX_COMMENTS_PER_STORY = 20
 
 seen_stories = set()
 seen_comments = set()
@@ -58,10 +59,9 @@ while True:
                 seen_stories.add(story_id)
                 logger.info("Story produced: %s", story.get('title'))
 
-                for comment_id in story.get('kids', [])[:50]:
+                for comment_id in story.get('kids', [])[:MAX_COMMENTS_PER_STORY]:
                     if comment_id in seen_comments:
                         continue
-
                     try:
                         comment = requests.get(f'{HN_API}/item/{comment_id}.json', timeout=10).json()
                         if comment:


### PR DESCRIPTION
This pull request updates both the data ingestion script and the notebook for writing to the Bronze layer. The main changes are a switch to an append-only write mode for Bronze (removing deduplication logic), and improvements to the Kafka ingestion script to avoid reprocessing the same stories and comments, as well as making the fetch interval and batch sizes configurable.

**Bronze Layer Write Logic:**

* Changed the Bronze write logic in `01_kafka_to_bronze.ipynb` from an upsert/merge (with deduplication) to a simple append-only mode, simplifying the data pipeline and improving write performance. The deduplication logic and related code were removed.

**Kafka Ingestion Script Improvements:**

* Increased the fetch interval from 60 to 90 seconds, and introduced `MAX_STORIES` and `MAX_COMMENTS_PER_STORY` constants for more flexible batch sizing in `utils/main.py`.
* Added sets (`seen_stories` and `seen_comments`) to track already-processed stories and comments, preventing duplicate ingestion. [[1]](diffhunk://#diff-c0b28b37146bb042e44e0dd81ab947d7e74f215909f6b253822fe907416e6706L11-R17) [[2]](diffhunk://#diff-c0b28b37146bb042e44e0dd81ab947d7e74f215909f6b253822fe907416e6706L43-R71)
* Modified the fetching logic to use the new constants and skip already-seen stories/comments, further reducing duplicates and unnecessary API calls.